### PR TITLE
added partial attribute removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Nestify is crafted for ease of learning, with its syntax tailored to be comforta
 - Simplify nested struct and enum definitions in Rust.
 - Make your codebase more readable and less verbose.
 - Ideal for modeling complex API responses.
-- Advanced attribute modifiers.
+- Advanced attribute modifiers for recursive propagation, single-item removal, propagation control, and structural partial removal.
 - Works well with Serde.
 - Intuitive syntax
 
@@ -317,7 +317,7 @@ nest! {
 ```rust
 #[apply_all]
 struct One {
-    two: Tow,
+    two: Two,
 }
 
 #[apply_all]
@@ -427,6 +427,101 @@ struct Four {}
 ```
 
 </details>
+
+#### Partial Attribute Removal
+
+For list-style attributes, `-` and `/` can remove part of an inherited attribute without removing the entire attribute.
+
+```rust
+nest! {
+    #[derive(Debug, Clone, PartialEq)]*
+    struct One {
+        two: #[derive(Debug)]-
+        struct Two {
+            value: i32,
+        }
+    }
+}
+```
+
+<details class="expand">
+    <summary>
+    Expand
+    </summary>
+    <br>
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+struct One {
+    two: Two,
+}
+
+#[derive(Clone, PartialEq)]
+struct Two {
+    value: i32,
+}
+```
+
+</details>
+
+This is especially useful when most nested types should share a derive, but one type needs to opt out of a specific trait.
+
+```rust
+nest! {
+    #[derive(Debug, Clone, Serialize, Deserialize)]*
+    pub struct One {
+        two: Option<
+            #[derive(Deserialize)]-
+            pub struct Two {
+                two: Option<String>,
+            }
+        >,
+    }
+}
+```
+
+In this example, `Two` keeps `Debug`, `Clone`, and `Serialize`, but removes `Deserialize` for that item only.
+
+#### Partial Removal with `cfg_attr`
+
+Partial removal also works structurally with nested list-style attributes such as `cfg_attr`.
+
+```rust
+nest! {
+    #[cfg_attr(all(), derive(Debug, Eq, PartialEq))]*
+    #[cfg_attr(all(), derive(Clone))]*
+    struct Foo {
+        field: #[cfg_attr(derive(Debug, Eq, Clone))]-
+        struct Bar {
+            value: u32,
+        }
+    }
+}
+```
+
+<details class="expand">
+    <summary>
+    Expand
+    </summary>
+    <br>
+
+```rust
+#[cfg_attr(all(), derive(Debug, Eq, PartialEq))]
+#[cfg_attr(all(), derive(Clone))]
+struct Foo {
+    field: Bar,
+}
+
+#[cfg_attr(all(), derive(PartialEq))]
+struct Bar {
+    value: u32,
+}
+```
+
+</details>
+
+> [!NOTE]
+> Partial removal is structural. Nestify removes matching comma-separated token groups from list-style attributes. It does not validate whether the resulting attribute is semantically meaningful for every possible custom or procedural macro attribute.
 
 ### Field Attributes **`#>[meta]`**
 

--- a/src/attribute_removal.rs
+++ b/src/attribute_removal.rs
@@ -1,0 +1,510 @@
+use crate::attributes::Attribute;
+use proc_macro2::{TokenStream, TokenTree};
+use quote::{quote, ToTokens};
+use syn::{Meta, MetaList};
+
+enum AttributeRemoval {
+    NoMatch,
+    RemoveWhole,
+    ReplaceWith(Meta),
+}
+
+enum ExistingAfter {
+    RemoveWhole,
+    ReplaceWith(Meta),
+}
+
+struct Consumption {
+    existing_after: ExistingAfter,
+    remaining_removal: Option<Meta>,
+}
+
+fn token_key(tokens: impl ToTokens) -> String {
+    tokens.to_token_stream().to_string()
+}
+
+fn same_path(left: &syn::Path, right: &syn::Path) -> bool {
+    token_key(left) == token_key(right)
+}
+
+fn same_delimiter(left: &syn::MacroDelimiter, right: &syn::MacroDelimiter) -> bool {
+    matches!(
+        (left, right),
+        (syn::MacroDelimiter::Paren(_), syn::MacroDelimiter::Paren(_))
+            | (syn::MacroDelimiter::Bracket(_), syn::MacroDelimiter::Bracket(_))
+            | (syn::MacroDelimiter::Brace(_), syn::MacroDelimiter::Brace(_))
+    )
+}
+
+fn is_cfgattr(path: &syn::Path) -> bool {
+    path.is_ident("cfg_attr")
+}
+
+fn split_commas(tokens: TokenStream) -> Vec<TokenStream> {
+    let mut items = Vec::new();
+    let mut current = TokenStream::new();
+
+    for token in tokens {
+        match &token {
+            TokenTree::Punct(punct) if punct.as_char() == ',' => {
+                if !current.is_empty() {
+                    items.push(current);
+                }
+
+                current = TokenStream::new();
+            }
+            _ => {
+                current.extend(std::iter::once(token));
+            }
+        }
+    }
+
+    if !current.is_empty() {
+        items.push(current);
+    }
+
+    items
+}
+
+fn join_comma_sep(items: Vec<TokenStream>) -> TokenStream {
+    let mut tokens = TokenStream::new();
+
+    for (idx, item) in items.into_iter().enumerate() {
+        if idx > 0 {
+            tokens.extend(quote!(,));
+        }
+
+        tokens.extend(item);
+    }
+
+    tokens
+}
+
+fn parse_meta(tokens: &TokenStream) -> Option<Meta> {
+    syn::parse2::<Meta>(tokens.clone()).ok()
+}
+
+fn rebuild_existing_meta_list(original: &MetaList, items: Vec<TokenStream>) -> Option<Meta> {
+    if items.is_empty() {
+        return None;
+    }
+
+    // cfg_attr(condition) alone is invalid/useless after payload removal
+    if is_cfgattr(&original.path) && items.len() <= 1 {
+        return None;
+    }
+
+    Some(Meta::List(MetaList {
+        path: original.path.clone(),
+        delimiter: original.delimiter.clone(),
+        tokens: join_comma_sep(items),
+    }))
+}
+
+fn rebuild_remaining_meta_list(original: &MetaList, items: Vec<TokenStream>) -> Option<Meta> {
+    if items.is_empty() {
+        return None;
+    }
+
+    Some(Meta::List(MetaList {
+        path: original.path.clone(),
+        delimiter: original.delimiter.clone(),
+        tokens: join_comma_sep(items),
+    }))
+}
+
+fn consume_item_from_items(
+    items: &mut Vec<TokenStream>,
+    removal_item: TokenStream,
+    min_existing_index: usize,
+) -> Option<Option<TokenStream>> {
+    // None => this item could not be consumed at all
+    // Some(None) => this item was fully consumed
+    // Some(Some(tokens)) => this item was partially consumed. tokens remain
+
+    let mut remaining = removal_item;
+    let mut changed = false;
+
+    loop {
+        let remaining_key = token_key(&remaining);
+
+        if let Some(idx) = (min_existing_index..items.len())
+            .find(|&idx| token_key(&items[idx]) == remaining_key)
+        {
+            items.remove(idx);
+            return Some(None);
+        }
+
+        let Some(removal_meta) = parse_meta(&remaining) else {
+            return if changed { Some(Some(remaining)) } else { None };
+        };
+
+        let mut found = false;
+
+        for idx in min_existing_index..items.len() {
+            let Some(existing_meta) = parse_meta(&items[idx]) else {
+                continue;
+            };
+
+            let Some(consumption) = consume_meta(&existing_meta, &removal_meta) else {
+                continue;
+            };
+
+            changed = true;
+            found = true;
+
+            match consumption.existing_after {
+                ExistingAfter::RemoveWhole => {
+                    items.remove(idx);
+                }
+                ExistingAfter::ReplaceWith(meta) => {
+                    items[idx] = meta.to_token_stream();
+                }
+            }
+
+            match consumption.remaining_removal {
+                None => return Some(None),
+                Some(meta) => {
+                    remaining = meta.to_token_stream();
+                    break;
+                }
+            }
+        }
+
+        if !found {
+            return if changed { Some(Some(remaining)) } else { None };
+        }
+    }
+}
+
+fn consume_meta(existing: &Meta, removal: &Meta) -> Option<Consumption> {
+    if token_key(existing) == token_key(removal) {
+        return Some(Consumption {
+            existing_after: ExistingAfter::RemoveWhole,
+            remaining_removal: None,
+        });
+    }
+
+    let (Meta::List(existing_list), Meta::List(removal_list)) = (existing, removal) else {
+        return None;
+    };
+
+    if !same_path(&existing_list.path, &removal_list.path) {
+        return None;
+    }
+
+    if !same_delimiter(&existing_list.delimiter, &removal_list.delimiter) {
+        return None;
+    }
+
+    let mut existing_items = split_commas(existing_list.tokens.clone());
+    let removal_items = split_commas(removal_list.tokens.clone());
+
+    if existing_items.is_empty() || removal_items.is_empty() {
+        return None;
+    }
+
+    // for cfg_attr, the first item is the condition
+    let existing_payload_start = if is_cfgattr(&existing_list.path) {
+        1
+    } else {
+        0
+    };
+
+    // cfg_attr(derive(Debug)) is shorthand
+    // cfg_attr(all(), derive(Debug)) targets a specific condition
+    let removal_has_explicit_cfg_condition =
+        is_cfgattr(&removal_list.path) && removal_items.len() >= 2;
+
+    if removal_has_explicit_cfg_condition {
+        let existing_condition = existing_items.first()?;
+        let removal_condition = &removal_items[0];
+
+        if token_key(existing_condition) != token_key(removal_condition) {
+            return None;
+        }
+    }
+
+    let removal_payload_start = if removal_has_explicit_cfg_condition {
+        1
+    } else {
+        0
+    };
+
+    let removal_payload_items = removal_items[removal_payload_start..].to_vec();
+
+    if removal_payload_items.is_empty() {
+        return None;
+    }
+
+    let mut changed = false;
+    let mut remaining_payload_items = Vec::new();
+
+    for removal_item in removal_payload_items {
+        match consume_item_from_items(
+            &mut existing_items,
+            removal_item.clone(),
+            existing_payload_start,
+        ) {
+            None => {
+                remaining_payload_items.push(removal_item);
+            }
+            Some(None) => {
+                changed = true;
+            }
+            Some(Some(remaining_item)) => {
+                changed = true;
+                remaining_payload_items.push(remaining_item);
+            }
+        }
+    }
+
+    if !changed {
+        return None;
+    }
+
+    let existing_after = match rebuild_existing_meta_list(existing_list, existing_items) {
+        Some(meta) => ExistingAfter::ReplaceWith(meta),
+        None => ExistingAfter::RemoveWhole,
+    };
+
+    let remaining_removal = if remaining_payload_items.is_empty() {
+        None
+    } else {
+        let mut remaining_items = Vec::new();
+
+        if removal_has_explicit_cfg_condition {
+            remaining_items.push(removal_items[0].clone());
+        }
+
+        remaining_items.extend(remaining_payload_items);
+
+        rebuild_remaining_meta_list(removal_list, remaining_items)
+    };
+
+    Some(Consumption {
+        existing_after,
+        remaining_removal,
+    })
+}
+
+pub fn remove_or_subtract_attr(stack: &mut Vec<Attribute>, removal: &Attribute) -> bool {
+    let original_stack = stack.clone();
+    let mut remaining = removal.meta.clone();
+
+    let mut idx = stack.len();
+
+    while idx > 0 {
+        idx -= 1;
+
+        let Some(consumption) = consume_meta(&stack[idx].meta, &remaining) else {
+            continue;
+        };
+
+        match consumption.existing_after {
+            ExistingAfter::RemoveWhole => {
+                stack.remove(idx);
+            }
+            ExistingAfter::ReplaceWith(meta) => {
+                stack[idx].meta = meta;
+            }
+        }
+
+        match consumption.remaining_removal {
+            None => return true,
+            Some(meta) => {
+                remaining = meta;
+            }
+        }
+    }
+
+    // partial failure must not mutate the stack.
+    *stack = original_stack;
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::Meta;
+
+    fn meta(input: &str) -> Meta {
+        syn::parse_str::<Meta>(input).unwrap()
+    }
+
+    fn subtract_meta(existing: &Meta, removal: &Meta) -> AttributeRemoval {
+        let Some(consumption) = consume_meta(existing, removal) else {
+            return AttributeRemoval::NoMatch;
+        };
+
+        if consumption.remaining_removal.is_some() {
+            return AttributeRemoval::NoMatch;
+        }
+
+        match consumption.existing_after {
+            ExistingAfter::RemoveWhole => AttributeRemoval::RemoveWhole,
+            ExistingAfter::ReplaceWith(meta) => AttributeRemoval::ReplaceWith(meta),
+        }
+    }
+
+    // we use this because of weird TokenStream::to_string()s
+    fn assert_replace_eq(result: AttributeRemoval, expected: &str) {
+        let expected = syn::parse_str::<Meta>(expected).unwrap();
+
+        match result {
+            AttributeRemoval::ReplaceWith(actual) => {
+                assert_eq!(token_key(actual), token_key(expected));
+            }
+            AttributeRemoval::RemoveWhole => {
+                panic!("expected replacement, got whole-attr removal");
+            }
+            AttributeRemoval::NoMatch => {
+                panic!("expected replacement, got no match");
+            }
+        }
+    }
+
+    #[test]
+    fn assert_basic_removal() {
+        let existing = meta("derive(Debug, Clone)");
+        let removal = meta("derive(Debug)");
+
+        assert_replace_eq(
+            subtract_meta(&existing, &removal),
+            "derive(Clone)",
+        );
+    }
+
+    #[test]
+    fn assert_cfg_attr_removal() {
+        let existing = meta("cfg_attr(all(), derive(Debug, Eq, PartialEq), derive(Clone))");
+        let removal = meta("cfg_attr(derive(Debug, Eq, Clone))");
+
+        assert_replace_eq(
+            subtract_meta(&existing, &removal),
+            "cfg_attr(all(), derive(PartialEq))",
+        );
+    }
+
+    #[test]
+    fn assert_rdoc_removal() {
+        let existing = meta(r#"doc = "hello""#);
+        let removal = meta(r#"doc = "hello""#);
+
+        assert!(matches!(
+            subtract_meta(&existing, &removal),
+            AttributeRemoval::RemoveWhole
+        ));
+    }
+
+    #[test]
+    fn assert_no_partial_rdoc_removal() {
+        let existing = meta(r#"doc = "hello""#);
+        let removal = meta(r#"doc = "hell""#);
+
+        assert!(matches!(
+            subtract_meta(&existing, &removal),
+            AttributeRemoval::NoMatch
+        ));
+    }
+
+    #[test]
+    fn assert_no_cross_match_removal() {
+        let existing = meta("foo(a, b)");
+        let removal = syn::parse_str::<Meta>("foo[a]").unwrap();
+
+        assert!(matches!(
+            subtract_meta(&existing, &removal),
+            AttributeRemoval::NoMatch
+        ));
+    }
+
+    #[test]
+    fn assert_cfg_attr_condition_exact_match() {
+        let existing = meta("cfg_attr(all(), derive(Debug))");
+        let removal = meta("cfg_attr(any(), derive(Debug))");
+
+        assert!(matches!(
+            subtract_meta(&existing, &removal),
+            AttributeRemoval::NoMatch
+        ));
+    }
+
+    #[test]
+    fn assert_no_cfg_attr_condition_removal() {
+        let existing = meta("cfg_attr(all(unix, windows), derive(Debug))");
+        let removal = meta("cfg_attr(all(unix))");
+
+        assert!(matches!(
+            subtract_meta(&existing, &removal),
+            AttributeRemoval::NoMatch
+        ));
+    }
+
+    #[test]
+    fn assert_whole_bracket_attr_removal() {
+        let existing = meta("foo[bar, baz]");
+        let removal = meta("foo[bar, baz]");
+
+        assert!(matches!(
+            subtract_meta(&existing, &removal),
+            AttributeRemoval::RemoveWhole
+        ));
+    }
+
+    #[test]
+    fn assert_attr_with_path_removal() {
+        let existing = meta("clippy::allow(dead_code, unused_variables)");
+        let removal = meta("clippy::allow(dead_code)");
+
+        assert_replace_eq(
+            subtract_meta(&existing, &removal),
+            "clippy::allow(unused_variables)",
+        );
+    }
+
+    #[test]
+    fn assert_attr_with_path_and_args_removal() {
+        let existing = meta(r#"custom("literal", flag)"#);
+        let removal = meta(r#"custom("literal")"#);
+
+        assert_replace_eq(
+            subtract_meta(&existing, &removal),
+            "custom(flag)",
+        );
+    }
+
+    #[test]
+    fn assert_nested_custom_attr_removal() {
+        let existing = meta("custom(foo(1, 10), flag)");
+        let removal = meta("custom(foo(1))");
+
+        assert_replace_eq(
+            subtract_meta(&existing, &removal),
+            "custom(foo(10), flag)",
+        );
+    }
+
+    #[test]
+    fn assert_failed_removal_rolls_back() {
+        let mut stack = vec![
+            Attribute { pound_token: Default::default(), bracket_token: Default::default(), meta: meta("cfg_attr(all(), derive(Debug, PartialEq))") },
+            Attribute { pound_token: Default::default(), bracket_token: Default::default(), meta: meta("cfg_attr(all(), derive(Clone))") },
+        ];
+
+        let original = stack.clone();
+
+        let removal = Attribute {
+            pound_token: Default::default(),
+            bracket_token: Default::default(),
+            meta: meta("cfg_attr(derive(Debug, Clone, Eq))"),
+        };
+
+        assert!(!remove_or_subtract_attr(&mut stack, &removal));
+
+        assert_eq!(
+        stack.iter().map(|attr| token_key(&attr.meta)).collect::<Vec<_>>(),
+        original.iter().map(|attr| token_key(&attr.meta)).collect::<Vec<_>>(),
+    );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod unpack_context;
 /// data structures annotated with custom attributes, facilitating a form of
 /// metaprogramming within Rust macros.
 pub(crate) mod unpack;
-
+mod attribute_removal;
 
 /// Allows for the expansion of "nested" items
 ///

--- a/src/unpack_context.rs
+++ b/src/unpack_context.rs
@@ -1,3 +1,4 @@
+use crate::attribute_removal::remove_or_subtract_attr;
 use crate::attributes::{Attribute, AttributeModifier, CompositeAttribute, FieldAttribute};
 
 #[derive(Clone, Default)]
@@ -45,16 +46,15 @@ impl UnpackContext {
                     AttributeModifier::Slash(_) => {
                         let a: Attribute = ca.into();
 
-                        // already defined so lets error
-                        if !freeze.contains(&a) {
+                        // remove from freeze
+                        if !remove_or_subtract_attr(&mut freeze, &a) {
                             panic!("not in the stack, dont need to remove (/)");
                         }
 
                         // remove from the future
-                        self.inherited.retain(|attr| attr != &a);
-
-                        // remove from freeze
-                        freeze.retain(|attr| attr != &a);
+                        if !remove_or_subtract_attr(&mut self.inherited, &a) {
+                            panic!("not in the inherited stack, cannot stop propagation (/)");
+                        }
 
                         // remove it from the current
                         None
@@ -62,15 +62,12 @@ impl UnpackContext {
                     AttributeModifier::Minus(_) => {
                         let a: Attribute = ca.into();
 
-                        // not in the stack so cant remove, lets error
-                        if !freeze.contains(&a) {
+                        // remove from freeze
+                        if !remove_or_subtract_attr(&mut freeze, &a) {
                             panic!("not in the stack, dont need to remove (-)");
                         }
 
                         // don't remove it from the future
-
-                        // remove from freeze
-                        freeze.retain(|attr| attr != &a);
 
                         // remove it from the current
                         None

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -191,3 +191,278 @@ fn augmented_types() {
     }
     
 }
+
+#[test]
+fn partial_attribute_removal() {
+    use std::fmt::{Debug};
+
+    // macros based off of https://github.com/nvzqz/static-assertions
+    macro_rules! does_impl_one {
+        ($ty:ty: $($trait_bound:tt)+) => {{
+            use core::marker::PhantomData;
+
+            trait DoesntImpl {
+                const DOES_IMPL: bool = false;
+            }
+
+            impl<T: ?Sized> DoesntImpl for T {}
+
+            struct Wrapper<T: ?Sized>(PhantomData<T>);
+
+            impl<T: ?Sized + $($trait_bound)+> Wrapper<T> {
+                const DOES_IMPL: bool = true;
+            }
+
+            <Wrapper<$ty>>::DOES_IMPL
+        }};
+    }
+
+    macro_rules! assert_impl_all {
+        ($ty:ty: $($trait_bound:path),+ $(,)?) => {{
+            $(
+                assert_eq!(
+                    does_impl_one!($ty: $trait_bound),
+                    true,
+                    "expected `{}` to implement `{}`",
+                    stringify!($ty),
+                    stringify!($trait_bound),
+                );
+            )+
+        }};
+    }
+
+    macro_rules! assert_impl_not_all {
+        ($ty:ty: $($trait_bound:path),+ $(,)?) => {{
+            let actual = true $(&& does_impl_one!($ty: $trait_bound))+;
+
+            assert_eq!(
+                actual,
+                false,
+                "expected `{}` to not implement all of `{}`",
+                stringify!($ty),
+                stringify!($($trait_bound),+),
+            );
+        }};
+    }
+
+    macro_rules! assert_impl_none {
+        ($ty:ty: $($trait_bound:path),+ $(,)?) => {{
+            $(
+                assert_impl_not_all!($ty: $trait_bound);
+            )+
+        }};
+    }
+
+    {
+        // test macros
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        struct Full;
+
+        struct Plain;
+
+        assert_impl_all!(Full: Debug, Clone, PartialEq, Eq);
+
+        assert_impl_none!(Plain: Debug, Clone, PartialEq, Eq);
+    }
+
+    {
+        nest! {
+        #[derive(Debug, Clone)]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[derive(Debug, Clone)]-
+                    struct Bar {
+                        foo: u32,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug, Clone);
+        assert_impl_none!(Bar: Debug, Clone);
+    }
+
+    {
+        nest! {
+            #[derive(Debug, Clone)]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[derive(Debug)]-
+                    struct Bar {
+                        child: std::marker::PhantomData<
+                            struct Baz {
+                                foo: u32,
+                            }
+                        >,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug, Clone);
+
+        assert_impl_all!(Bar: Clone);
+        assert_impl_none!(Bar: Debug);
+
+        // - only affects the current item, not descendants
+        assert_impl_all!(Baz: Debug, Clone);
+    }
+
+    {
+        nest! {
+            #[derive(Debug, Clone)]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[derive(Debug)]/
+                    struct Bar {
+                        child: std::marker::PhantomData<
+                            struct Baz {
+                                foo: u32,
+                            }
+                        >,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug, Clone);
+
+        assert_impl_all!(Bar: Clone);
+        assert_impl_none!(Bar: Debug);
+
+        // / affects descendants too
+        assert_impl_all!(Baz: Clone);
+        assert_impl_none!(Baz: Debug);
+    }
+
+    {
+        nest! {
+            #[cfg_attr(all(), derive(Debug, Eq, PartialEq), derive(Clone))]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[cfg_attr(derive(Debug, Eq, Clone))]-
+                    struct Bar {
+                        foo: u32,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug, Clone, PartialEq, Eq);
+
+        // expected #[cfg_attr(all(), derive(PartialEq))] leftover
+        assert_impl_all!(Bar: PartialEq);
+        assert_impl_none!(Bar: Debug, Clone, Eq);
+    }
+
+    {
+        nest! {
+            #[cfg_attr(all(), derive(Debug))]*
+            #[cfg_attr(any(), derive(Clone))]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[cfg_attr(derive(Clone))]-
+                    struct Bar {
+                        foo: u32,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug);
+        assert_impl_none!(Foo: Clone);
+
+        // if this expansion leaves #[cfg_attr(any())], this test should fail before assertions even run
+        assert_impl_all!(Bar: Debug);
+        assert_impl_none!(Bar: Clone);
+    }
+
+    {
+        nest! {
+            #[cfg_attr(all(), derive(Debug, Eq, PartialEq))]*
+            #[cfg_attr(all(), derive(Clone))]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[cfg_attr(derive(Debug, Eq, Clone))]-
+                    struct Bar {
+                        foo: u32,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug, Clone, PartialEq, Eq);
+
+        // expected #[cfg_attr(all(), derive(PartialEq))] leftover
+        assert_impl_all!(Bar: PartialEq);
+        assert_impl_none!(Bar: Debug, Clone, Eq);
+    }
+
+    {
+        nest! {
+            #[cfg_attr(all(), derive(Debug))]*
+            #[cfg_attr(any(), derive(Debug))]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[cfg_attr(derive(Debug))]-
+                    struct Bar {
+                        foo: u32,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug);
+
+        // the nearest matching cfg_attr is the inactive any() one. should leave the all() one intact
+        assert_impl_all!(Bar: Debug);
+    }
+
+    {
+        nest! {
+            #[cfg_attr(all(), derive(Debug, Eq, PartialEq), derive(Clone))]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[cfg_attr(derive(Debug, Clone))]/
+                    struct Bar {
+                        child: std::marker::PhantomData<
+                            struct Baz {
+                                foo: u32,
+                            }
+                        >,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug, Clone, PartialEq, Eq);
+
+        // expected #[cfg_attr(all(), derive(Eq, PartialEq))] leftover for Bar and Baz
+        assert_impl_all!(Bar: PartialEq, Eq);
+        assert_impl_none!(Bar: Debug, Clone);
+
+        assert_impl_all!(Baz: PartialEq, Eq);
+        assert_impl_none!(Baz: Debug, Clone);
+    }
+
+    {
+        nest! {
+            #[cfg_attr(all(), derive(Debug))]*
+            #[cfg_attr(any(), derive(Clone))]*
+            struct Foo {
+                field: std::marker::PhantomData<
+                    #[cfg_attr(any(), derive(Clone))]-
+                    struct Bar {
+                        foo: u32,
+                    }
+                >,
+            }
+        }
+
+        assert_impl_all!(Foo: Debug);
+        assert_impl_none!(Foo: Clone);
+
+        assert_impl_all!(Bar: Debug);
+        assert_impl_none!(Bar: Clone);
+    }
+}


### PR DESCRIPTION
Adds recursive attribute removal for - and /.

Previously, attribute removal required the attribute to exactly match an inherited attribute. This meant that group/list style attributes could not be removed. 

For example, this would fail because #[derive(Debug)] was not considered the same stack entry as #[derive(Debug, Clone)].
```rust
nest! {
    #[derive(Debug, Clone)]*
    struct Foo {
        field: #[derive(Debug)]-
        struct Bar {
            value: u32,
        }
    }
}
```

This pr adds structural partial removal for those list style attributes, allowing the above to expand with Bar keeping Clone but not Debug.

Grouped derive now works
```rust
nest! {
    #[derive(Debug, Clone, PartialEq)]*
    struct One {
        two: #[derive(Debug)]-
        struct Two {
            value: i32,
        }
    }
}
```
expands to
```rust
#[derive(Debug, Clone, PartialEq)]
struct One {
    two: Two,
}

#[derive(Clone, PartialEq)]
struct Two {
    value: i32,
}
```

More complex cfg_attr also works
```rust
nest! {
    #[cfg_attr(all(), derive(Debug, Eq, PartialEq))]*
    #[cfg_attr(all(), derive(Clone))]*
    struct Foo {
        field: #[cfg_attr(derive(Debug, Eq, Clone))]-
        struct Bar {
            value: u32,
        }
    }
}
```
expands to
```
#[cfg_attr(all(), derive(Debug, Eq, PartialEq))]
#[cfg_attr(all(), derive(Clone))]
struct Foo {
    field: Bar,
}

#[cfg_attr(all(), derive(PartialEq))]
struct Bar {
    value: u32,
}
```

Partial removal is structural, not semantic. It does not attempt to validate whether the resulting attribute is meaningful for every possible custom or procedural macro attribute.

Also added lots of tests :3